### PR TITLE
#4admin units

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem "net-smtp"
 gem "net-imap"
 gem "net-pop"
 
+# ruby hash as a readonly datasource for an ActiveRecord-like model
+gem "active_hash"
+
 group :development, :test do
   # デバッグ
   gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.1.5)
       activesupport (= 6.1.5)
       globalid (>= 0.3.6)
@@ -338,6 +340,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_hash
   annotate
   better_errors
   binding_of_caller

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Unit < ActiveYaml::Base
+  include ActiveHash::Associations
+
+  set_root_path Rails.root.join("config/masters")
+  set_filename "unit"
+
+  # has_many :questions
+end

--- a/config/masters/unit.yml
+++ b/config/masters/unit.yml
@@ -1,0 +1,84 @@
+# 数学I
+- id: 1
+  name: "数と式・集合と論理"
+  subject: 数学I
+- id: 2
+  name: "図形と計量"
+  subject: 数学I
+- id: 3
+  name: "二次関数"
+  subject: 数学I
+- id: 4
+  name: "データの分析"
+  subject: 数学I
+
+# 数学II
+- id: 5
+  name: "式と証明"
+  subject: 数学II
+- id: 6
+  name: "複素数と方程式"
+  subject: 数学II
+- id: 7
+  name: "図形と方程式"
+  subject: 数学II
+- id: 8
+  name: "三角関数"
+  subject: 数学II
+- id: 9
+  name: "指数・対数関数"
+  subject: 数学II
+- id: 10
+  name: "微分"
+  subject: 数学II
+- id: 11
+  name: "積分"
+  subject: 数学II
+
+# 数学III
+- id: 12
+  name: "複素数平面"
+  subject: 数学III
+- id: 13
+  name: "式と曲線"
+  subject: 数学III
+- id: 14
+  name: "関数"
+  subject: 数学III
+- id: 15
+  name: "極限"
+  subject: 数学III
+- id: 16
+  name: "微分"
+  subject: 数学III
+- id: 17
+  name: "積分"
+  subject: 数学III
+
+# 数学A
+- id: 18
+  name: "場合の数"
+  subject: 数学A
+- id: 19
+  name: "確率"
+  subject: 数学A
+- id: 20
+  name: "整数"
+  subject: 数学A
+- id: 21
+  name: "図形の性質"
+  subject: 数学A
+
+# 数学B
+- id: 22
+  name: "平面ベクトル"
+  subject: 数学B
+- id: 23
+  name: "空間ベクトル"
+  subject: 数学B
+- id: 24
+  name: "数列"
+  subject: 数学B
+- id: 25
+  name: "確率分布と統計的な推測"
+  subject: 数学B


### PR DESCRIPTION
## 概要
詳細は issue #4 をご覧ください。
gem Active Hash を用いて Unitモデルを作成しました。

## 確認方法
1. Gem を追加したので `bundle install` を実行してください

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しておきましょう。例えば以下のように。

- [ ] rubocopをパスした
- [ ] rails_best_practicesをパスした

## コメント
- Active Hashを用いて、2つのモデル Unit（単元） と Subject (科目)を作成し、Subject has_many Unit の関連を持たせようとしたができなかったため、それらをひとまとめにしたモデル Unit を作成することにしました。
- モデル Unit のデータconfig/master/unit.yml を https://github.com/active-hash/active_hash#using-aliases-in-yaml にならって `include ActiveYaml::Aliases` をして、エイリアス、アンカーを利用して記述しようとしましたが、うまくいきませんでした。うまくいかなかったコードは次の通りです。
  models/unit.rb  
  ```
  # frozen_string_literal: true

  class Unit < ActiveYaml::Base
    include ActiveHash::Associations
    include ActiveYaml::Aliases

    set_root_path Rails.root.join("config/masters")
    set_filename "unit"
  end
  ```
  config/masters/unit.yml
  ```
  - /aliases:
    subject: &subject1
      数学I

  # 数学I
  - id: 1
    name: "数と式・集合と論理"
    subject: *subject1
  （以下略）
  ```
  コンソールで次のようなエラーが出ました。
  ```
  irb(main):007:0> Unit.first
  /Users/fujitamasashi/.rbenv/versions/3.1.1/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: subject1 (Psych::BadAlias) 
  ```
  おそらく、原因はruby3.1でPsych のバージョンが3から4になったことのようです。
  参考：https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias
  ActiveHashの方ではこちらで対応されるようですが、未だ対応は完了されていません。
  https://github.com/active-hash/active_hash/pull/246
  そのため、config/masters/unit.yml はアンカー、エイリアスを用いない冗長な記述になっています。
  ActiveHashの対応が完了次第修正したいと思います。
- Unit のモデルスペックは次のPRに含めます。