### PR TITLE
ユーザーの解答、問題・解答検索一覧のajax通信中に表示するspinnerの位置を変更

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,7 +20,7 @@ import "src/answers/Form"
 import "src/answers/Index"
 import "src/answers/SearchTags"
 import "src/answers/CreateEditTags"
-
+import "src/Loading"
 
 
 const images = require.context("../images", true);

--- a/app/javascript/src/Loading.js
+++ b/app/javascript/src/Loading.js
@@ -1,0 +1,39 @@
+$(function(){
+  const scrollToElem = document.querySelector('.scroll-to');
+  const spinnerWrapper = $('<div class="d-flex justify-content-center align-items-center", style="height: 10rem;"></div>')
+  const spinner = $('<div class="spinner-border", style="width: 1.5rem; height: 1.5rem;", role="status">');
+  spinnerWrapper.append(spinner);
+  // ajax開始前
+  document.body.addEventListener("ajax:before", (event) => {
+    if(event.target.classList.contains("loading")){
+      $(".loaded").html(spinnerWrapper);
+      // スピナー
+      scrollToElem.scrollIntoView();
+
+    }
+  });
+});
+
+/*
+タイトル横にスピナーを表示する場合
+$(function(){
+  const scrollToElem = document.querySelector('.scroll-to');
+  const spinner = $('<div class="spinner-border d-inline ms-4", style="width: 1.5rem; height: 1.5rem;", role="status">');
+  // ajax開始前
+  document.body.addEventListener("ajax:before", (event) => {
+    if(event.target.classList.contains("loading")){
+      // 問題一覧でのスピナー
+      $(scrollToElem).append(spinner);
+      scrollToElem.scrollIntoView();
+      // ajax終了時
+      event.target.addEventListener("ajax:success", (event) => {
+        // 問題一覧でのスピナー
+        const spinner = $('.scroll-to .spinner-border');
+        if(spinner){
+          spinner.remove();
+        }
+      });
+    }
+  });
+});
+*/

--- a/app/javascript/src/questions/Index.js
+++ b/app/javascript/src/questions/Index.js
@@ -45,23 +45,4 @@ $(function(){
     var dropDownButton = $('.search-form-universities button');
     displayCheckedUniversityNamesOnDropDownButton(checkedBoxes, dropDownButton);
   });
-
-  const scrollToElem = document.querySelector('.scroll-to');
-  const spinner = $('<div class="spinner-border d-inline ms-4", style="width: 1.5rem; height: 1.5rem;", role="status">');
-  // ajax開始前
-  document.body.addEventListener("ajax:before", (event) => {
-    if(event.target.classList.contains("loading")){
-      // 問題一覧でのスピナー
-      $(scrollToElem).append(spinner);
-      scrollToElem.scrollIntoView();
-      // ajax終了時
-      event.target.addEventListener("ajax:success", (event) => {
-        // 問題一覧でのスピナー
-        const spinner = $('.scroll-to .spinner-border');
-        if(spinner){
-          spinner.remove();
-        }
-      });
-    }
-  });
 });

--- a/app/views/answers/_answers.html.slim
+++ b/app/views/answers/_answers.html.slim
@@ -1,6 +1,6 @@
 / 画面サイズmd以上：2列、md以下:1列
 .container
-  .row id="answers-index"
+  .row.loaded id="answers-index"
     / カード部分
     = content_for :answer_partial
 

--- a/app/views/shared/questions/_index.html.slim
+++ b/app/views/shared/questions/_index.html.slim
@@ -97,7 +97,7 @@
 
   / 問題カードの一覧
   .container
-    .row. id="questions-index"
+    .row.loaded id="questions-index"
       = content_for :question_partial
 
 / ページネーション


### PR DESCRIPTION
## 概要
こちらは pull request #44 の修正になります。
以下のように表示されるよう、spinnerの位置を変更いたしました。

<img width="1156" alt="スクリーンショット 2022-07-23 11 26 35" src="https://user-images.githubusercontent.com/88495850/180587167-26a9ddc3-f050-4a39-9fd9-4b15e881dffb.png">

## 実装内容
スピナー要素の親要素にloadedというクラス名を付与し、ajax通信開始前に親要素の内容をスピナーに置き換える処理をjavascript/src/Loading.jsに作成しました。
ajax通信後、スピナーが問題あるいは解答一覧に置き換えられます。

## チェックリスト
- [ ] rubocopをパスした
- [ ] rails_best_practicesをパスした
- [ ] モデルスペックを作成し、パスした
- [ ] システムスペックを作成し、パスした

